### PR TITLE
Removed "use vars ..." in favour of "our"

### DIFF
--- a/lib/HTML/Scrubber.pm
+++ b/lib/HTML/Scrubber.pm
@@ -61,7 +61,7 @@ use strict;
 use warnings;
 use HTML::Parser();
 use HTML::Entities;
-use vars qw[ @_scrub @_scrub_fh ];
+our( @_scrub, @_scrub_fh );
 
 # my my my my, these here to prevent foolishness like
 # http://perlmonks.org/index.pl?node_id=251127#Stealing+Lexicals


### PR DESCRIPTION
According to https://metacpan.org/module/vars, "vars" pragma is obsolete. The use of "our" should be semantically equal:
prove -l t/
t/01_use.t ........... ok
t/02_basic.t ......... ok
t/03_more.t .......... ok
t/04_style_script.t .. ok
t/05_pi_comment.t .... ok
t/06_scrub_file.t .... ok
t/07_booleans.t ...... ok
All tests successful.
Files=7, Tests=122,  0 wallclock secs ( 0.08 usr  0.01 sys +  0.27 cusr  0.04 csys =  0.40 CPU)
Result: PASS
