### PR TITLE
check for definedness before calling ->parse

### DIFF
--- a/lib/HTML/Scrubber.pm
+++ b/lib/HTML/Scrubber.pm
@@ -330,7 +330,7 @@ sub scrub {
 
     $_[0]->_optimize();# if $_[0]->{_optimize};
 
-    $_[0]->{_p}->parse($_[1]);
+    $_[0]->{_p}->parse($_[1]) if defined($_[1]);
     $_[0]->{_p}->eof();
 
     return delete $_[0]->{_r} unless exists $_[0]->{_out};

--- a/t/09_no_scrub_warnings.t
+++ b/t/09_no_scrub_warnings.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+
+use_ok('HTML::Scrubber');
+use HTML::Scrubber;
+
+my $scrubber = HTML::Scrubber->new;
+
+# really one of the Test:: warnings would be better here
+# but lets keep this simple
+local $SIG{__WARN__} = sub {
+	fail( "warning raised by scrub: @_" );
+};
+
+ok( ! $scrubber->scrub );
+ok( ! $scrubber->scrub('') );
+ok( ! $scrubber->scrub('<html></html>') );
+
+done_testing;


### PR DESCRIPTION
on $_[1] in sub scrub, otherwise we get:

  Use of uninitialized value in subroutine entry

which isn't helpful and fills up logs. really scrub shouldn't be
called sans a second argument, but probably a good idea to do the
right thing here too