### PR TITLE
Removed the link to HTML::Sanitizer

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -319,7 +319,9 @@ If you have Test::Inline (and you've installed HTML::Scrubber), try
 
 =head1 SEE ALSO
 
-L<HTML::Parser>, L<Test::Inline>, L<HTML::Sanitizer>.
+L<HTML::Parser>, L<Test::Inline>.
+
+The HTML::Sanitizer module is no longer available on CPAN.
 
 =head1 INSTALLATION
 

--- a/lib/HTML/Scrubber.pm
+++ b/lib/HTML/Scrubber.pm
@@ -59,6 +59,8 @@ use strict;
 use warnings;
 use HTML::Parser 3.47 ();
 use HTML::Entities;
+use Scalar::Util ('weaken');
+
 our( @_scrub, @_scrub_fh );
 
 # VERSION
@@ -96,6 +98,7 @@ sub new {
     };
 
     $p->{"\0_s"} = bless $self, $package;
+    weaken($p->{"\0_s"});
 
     return $self unless @_;
 
@@ -542,9 +545,6 @@ sub _optimize {
 }
 
 
-sub DESTROY {
-    delete $_[0]->{_p}->{"\0_s"}; # break circular reference
-}
 1;
 
 #print sprintf q[ '%-12s => %s,], "$_'", $h{$_} for sort keys %h;# perl!

--- a/lib/HTML/Scrubber.pm
+++ b/lib/HTML/Scrubber.pm
@@ -705,6 +705,8 @@ If you have Test::Inline (and you've installed HTML::Scrubber), try
 
 =head1 SEE ALSO
 
-L<HTML::Parser>, L<Test::Inline>, L<HTML::Sanitizer>.
+L<HTML::Parser>, L<Test::Inline>.
+
+The HTML::Sanitizer module is no longer available on CPAN.
 
 =cut

--- a/t/09_memory_cycle.t
+++ b/t/09_memory_cycle.t
@@ -1,0 +1,9 @@
+
+use Test::More tests => 1;
+use Test::Memory::Cycle;
+
+use HTML::Scrubber;
+
+my $scrubber = HTML::Scrubber->new();
+
+memory_cycle_ok($scrubber, "Scrubber has no cycles");


### PR DESCRIPTION
The link was broken. It was replaced by an explanation that the HTML::Sanitizier is
no longer on CPAN.