### PR TITLE
Removed circular reference

### DIFF
--- a/lib/HTML/Scrubber.pm
+++ b/lib/HTML/Scrubber.pm
@@ -59,6 +59,8 @@ use strict;
 use warnings;
 use HTML::Parser 3.47 ();
 use HTML::Entities;
+use Scalar::Util ('weaken');
+
 our( @_scrub, @_scrub_fh );
 
 # VERSION
@@ -96,6 +98,7 @@ sub new {
     };
 
     $p->{"\0_s"} = bless $self, $package;
+    weaken($p->{"\0_s"});
 
     return $self unless @_;
 
@@ -542,9 +545,6 @@ sub _optimize {
 }
 
 
-sub DESTROY {
-    delete $_[0]->{_p}->{"\0_s"}; # break circular reference
-}
 1;
 
 #print sprintf q[ '%-12s => %s,], "$_'", $h{$_} for sort keys %h;# perl!

--- a/t/09_memory_cycle.t
+++ b/t/09_memory_cycle.t
@@ -1,0 +1,9 @@
+
+use Test::More tests => 1;
+use Test::Memory::Cycle;
+
+use HTML::Scrubber;
+
+my $scrubber = HTML::Scrubber->new();
+
+memory_cycle_ok($scrubber, "Scrubber has no cycles");


### PR DESCRIPTION
The delete of the circular reference at DESTROY was replaced with a weaken call.
That way, we removed the circular reference and we  can test that there are no
other circular refences.