### PR TITLE
Enable Travis Continuous Integration builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ install:
   - cpanm --quiet --notest --skip-satisfied Dist::Zilla
   
   - cpanm --quiet --notest --skip-satisfied Pod::Markdown
+  
+  - cpanm --quiet --notest Test::CPAN::Meta
 
   - dzil authordeps | grep -vP '[^\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest --skip-satisfied
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ install:
   
   - cpanm --quiet --notest --skip-satisfied Pod::Markdown
   
+  - cpanm --quiet --notest --skip-satisfied Test::EOL
+  
+  - cpanm --quiet --notest --skip-satisfied Test::NoTabs
+  
   - dzil authordeps | grep -vP '[^\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest --skip-satisfied
 
   - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=j10:c HARNESS_TIMER=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ install:
   
   - cpanm --quiet --notest --skip-satisfied Pod::Markdown
   
-  - cpanm --quiet --notest Test::CPAN::Meta
-
   - dzil authordeps | grep -vP '[^\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest --skip-satisfied
 
   - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=j10:c HARNESS_TIMER=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: perl
+perl: 
+  - "5.20"
+  - "5.18"
+#  - "5.16"
+#  - "5.14"
+
+before_install:
+
+  # prevent "plelase tell me who you are errors for certain DZIL configs
+  - git config --global user.name "Travis CI"
+
+install:
+
+  # Deal with all the DZIL dependencies, quickly and quietly
+
+  - cpanm --quiet --notest --skip-satisfied Dist::Zilla
+  
+  - cpanm --quiet --notest --skip-satisfied Pod::Markdown
+
+  - dzil authordeps | grep -vP '[^\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest --skip-satisfied
+
+  - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
+
+  - dzil listdeps | grep -vP '[^\w:]' | cpanm --verbose
+
+script:
+
+  - dzil test

--- a/README.pod
+++ b/README.pod
@@ -8,11 +8,7 @@ HTML::Scrubber - Perl extension for scrubbing/sanitizing html
 
 =head1 VERSION
 
-version 0.11
-
-=head1 BUILD
-
-L<Master Build Results|https://travis-ci.org/mrcaron/html-scrubber>
+version 0.12
 
 =head1 SYNOPSIS
 
@@ -362,8 +358,9 @@ D. H. <podmaster@cpan.org>
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2013 by Ruslan Zakirov, Nigel Metheringham, 2003-2004 D. H..
+This software is copyright (c) 2015 by Ruslan Zakirov, Nigel Metheringham, 2003-2004 D. H..
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
 
+=cut

--- a/README.pod
+++ b/README.pod
@@ -10,6 +10,10 @@ HTML::Scrubber - Perl extension for scrubbing/sanitizing html
 
 version 0.11
 
+=head1 BUILD
+
+L<Master Build Results|https://travis-ci.org/mrcaron/html-scrubber>
+
 =head1 SYNOPSIS
 
     use HTML::Scrubber;

--- a/dist.ini
+++ b/dist.ini
@@ -11,8 +11,9 @@ dist                        = HTML-Scrubber
 repository_at               = github
 disable_pod_coverage_tests  = 1
 
+[Test::EOL]
+[Test::NoTabs]
+
 [Prereqs]
-Test::EOL = 0
-Test::NoTabs = 0
 Test::CPAN::Meta = 0
 

--- a/dist.ini
+++ b/dist.ini
@@ -10,3 +10,7 @@ main_module                 = lib/HTML/Scrubber.pm
 dist                        = HTML-Scrubber
 repository_at               = github
 disable_pod_coverage_tests  = 1
+
+[Prereqs]
+Test::EOL = 0
+Test::NoTabs = 0

--- a/dist.ini
+++ b/dist.ini
@@ -14,3 +14,5 @@ disable_pod_coverage_tests  = 1
 [Prereqs]
 Test::EOL = 0
 Test::NoTabs = 0
+Test::CPAN::Meta = 0
+

--- a/dist.ini
+++ b/dist.ini
@@ -13,6 +13,6 @@ disable_pod_coverage_tests  = 1
 
 [Prereqs / TestRequires]
 Test::CPAN::Meta = 0
-Test::EOL = 0;
-Test::NoTabs = 0;
+Test::EOL = 0
+Test::NoTabs = 0
 

--- a/dist.ini
+++ b/dist.ini
@@ -11,7 +11,7 @@ dist                        = HTML-Scrubber
 repository_at               = github
 disable_pod_coverage_tests  = 1
 
-[Prereqs]
+[Prereqs / TestRequires]
 Test::CPAN::Meta = 0
 Test::EOL = 0;
 Test::NoTabs = 0;

--- a/dist.ini
+++ b/dist.ini
@@ -11,9 +11,6 @@ dist                        = HTML-Scrubber
 repository_at               = github
 disable_pod_coverage_tests  = 1
 
-[Test::EOL]
-[Test::NoTabs]
-
 [Prereqs]
 Test::CPAN::Meta = 0
 

--- a/dist.ini
+++ b/dist.ini
@@ -13,4 +13,6 @@ disable_pod_coverage_tests  = 1
 
 [Prereqs]
 Test::CPAN::Meta = 0
+Test::EOL = 0;
+Test::NoTabs = 0;
 


### PR DESCRIPTION
I've been doing this lately. It allows me to offload these Dist::Zilla plugins to the Travis server and let me focus on other things. This PR adjusts the dist.init to allow for the modules in your plugin that are deprecated (see other PR for your plugin) and includes the necessary .travis.yml file for building and running tests in the cloud.