### PR TITLE
Add missing testing prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,4 +11,9 @@ dist                        = HTML-Scrubber
 repository_at               = github
 disable_pod_coverage_tests  = 1
 
+[Prereqs / TestRequires]
+Test::EOL        = 0
+Test::NoTabs     = 0
+Test::CPAN::Meta = 0
+
 ; end


### PR DESCRIPTION
Upon running the tests on Travis I found that some of the required testing modules were missing.  This PR adds the missing modules to the list of `TestRequires` prereqs and the tests now pass again on Travis.

This PR is submitted in the hope that it is useful.  If you have any questions or comments concerning it, please let me know and I'll update as required and resubmit.