### PR TITLE
Avoid pod-spell test failure from ABSTRACT text

### DIFF
--- a/lib/HTML/Scrubber.pm
+++ b/lib/HTML/Scrubber.pm
@@ -1,6 +1,6 @@
 package HTML::Scrubber;
 
-# ABSTRACT: Perl extension for scrubbing/sanitizing html
+# ABSTRACT: Perl extension for scrubbing/sanitizing HTML
 
 =begin :prelude
 


### PR DESCRIPTION
It turns out that because the `:prelude` has to come after the
Dist::Zilla `ABSTRACT` line that the text in the ABSTRACT comment is
checked for spelling errors by the pod-spell test.  This test fails on
Debian "stretch" Linux in Perl 5.20.3 with `Test::Spelling` version
0.20, complaining about the word "html". (frustratingly, it *doesn't*
fail on Travis, i.e. Ubuntu...).  Nevertheless, the fix is simple, one
simply needs to capitalise the word "html" in the ABSTRACT and the test
is happy again.