### PR TITLE
Fix perlcritic issues

### DIFF
--- a/t/01_use.t
+++ b/t/01_use.t
@@ -1,5 +1,8 @@
 # Check this module loads
-#
+
+use strict;
+use warnings;
+
 use Test::More tests => 1;
 
 BEGIN {

--- a/t/02_basic.t
+++ b/t/02_basic.t
@@ -5,6 +5,9 @@
 
 # change 'tests => 1' to 'tests => last_test_to_print';
 
+use strict;
+use warnings;
+
 use Test;
 BEGIN { plan tests => 77 }
 use HTML::Scrubber;

--- a/t/06_scrub_file.t
+++ b/t/06_scrub_file.t
@@ -26,7 +26,7 @@ SKIP: {
     is( $r, 1, "scrub(\$html,\$tmpfile=$tmpfile)" );
 
     local *FILIS;
-    open FILIS, "+>$tmpfile" or die "can't write to $tmpfile";
+    open FILIS, "+>", $tmpfile or die "can't write to $tmpfile";
 
     $r = $s->scrub( $html, \*FILIS );
     $r = "Error: \$@=$@ \$!=$!" unless $r;
@@ -44,7 +44,7 @@ SKIP: {
 
     is( $r, 1, qq[scrub_file(\$tmpfile,"\$tmpfile2"=$tmpfile2)] );
 
-    open FILIS, "+>$tmpfile2" or die "can't write to $tmpfile";
+    open FILIS, "+>", $tmpfile2 or die "can't write to $tmpfile";
     $r = $s->scrub_file( $tmpfile, \*FILIS );
     $r = "Error: \$@=$@ \$!=$!" unless $r;
 

--- a/t/06_scrub_file.t
+++ b/t/06_scrub_file.t
@@ -25,18 +25,17 @@ SKIP: {
     $r = "Error: \$@=$@ \$!=$!" unless $r;
     is( $r, 1, "scrub(\$html,\$tmpfile=$tmpfile)" );
 
-    local *FILIS;
-    open FILIS, "+>", $tmpfile or die "can't write to $tmpfile";
+    open my $filis, "+>", $tmpfile or die "can't write to $tmpfile";
 
-    $r = $s->scrub( $html, \*FILIS );
+    $r = $s->scrub( $html, $filis );
     $r = "Error: \$@=$@ \$!=$!" unless $r;
 
-    is( $r, 1, q[scrub($html,\*FILIS)] );
+    is( $r, 1, q[scrub($html, $filis)] );
 
-    seek *FILIS, 0, 0;
-    $r = join '', readline *FILIS;
-    is( $r, "histart  mid1  mid2  end", "FILIS has the right stuff" );
-    is( close(FILIS), 1, q[close(FILIS)] );
+    seek $filis, 0, 0;
+    $r = join '', readline $filis;
+    is( $r, "histart  mid1  mid2  end", '$filis has the right stuff' );
+    is( close($filis), 1, q[close($filis)] );
 
     my ( $tfh2, $tmpfile2 ) = tempfile( $template, DIR => $tmpdir, SUFFIX => '.html' );
     $r = $s->scrub_file( $tmpfile, "$tmpfile2" );
@@ -44,14 +43,14 @@ SKIP: {
 
     is( $r, 1, qq[scrub_file(\$tmpfile,"\$tmpfile2"=$tmpfile2)] );
 
-    open FILIS, "+>", $tmpfile2 or die "can't write to $tmpfile";
-    $r = $s->scrub_file( $tmpfile, \*FILIS );
+    open $filis, "+>", $tmpfile2 or die "can't write to $tmpfile";
+    $r = $s->scrub_file( $tmpfile, $filis );
     $r = "Error: \$@=$@ \$!=$!" unless $r;
 
-    is( $r, 1, q[scrub_file($tmpfile,\*FILIS)] );
-    seek *FILIS, 0, 0;
-    $r = join '', readline *FILIS;
-    is( $r, "histart  mid1  mid2  end", "FILIS has the right stuff" );
-    is( close(FILIS), 1, q[close(FILIS)] );
+    is( $r, 1, q[scrub_file($tmpfile, $filis)] );
+    seek $filis, 0, 0;
+    $r = join '', readline $filis;
+    is( $r, "histart  mid1  mid2  end", '$filis has the right stuff' );
+    is( close($filis), 1, q[close($filis)] );
 
 }

--- a/t/09_memory_cycle.t
+++ b/t/09_memory_cycle.t
@@ -1,3 +1,5 @@
+use strict;
+use warnings;
 
 use Test::More tests => 1;
 use Test::Memory::Cycle;


### PR DESCRIPTION
This pull request gets the dist to pass the basic level of perlcritic checks.  Some test files were missing the `strict` pragma, some needed to use the three-argument form of the `open` statement, and some were using bareword filehandles.  These issues have been fixed in this PR.

If you have any questions or comments, please don't hesitate to contact me!