### PR TITLE
Fix stale URLs

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -15,7 +15,7 @@
         # Break before all operators:
 -wbb="% + - * / x != == >= <= =~ < > | & **= += *= &= <<= &&= -= /= |= >>= ||= .= %= ^= x="
 # Note that the PBP book has a typo on page 35 when defining the above -wbb
-# option, see http://oreilly.com/catalog/perlbp/errata/perlbp.confirmed
+# option, see http://www.oreilly.com/catalog/errata.csp?isbn=9780596001735
 # The above string is correct.
 
 #----------  Perltidy default options (i.e. in line with PBP)  --------------

--- a/lib/HTML/Scrubber.pm
+++ b/lib/HTML/Scrubber.pm
@@ -456,7 +456,7 @@ sub _scrub_str {
         $outstr .= $text if $s->{_process};
     }
     elsif ( $e eq 'text' or $e eq 'default' ) {
-        $text =~ s/</&lt;/g;    #https://rt.cpan.org/Ticket/Attachment/8716/10332/scrubber.patch
+        $text =~ s/</&lt;/g;    #https://rt.cpan.org/Public/Ticket/Attachment/83958/10332/scrubber.patch
         $text =~ s/>/&gt;/g;
 
         $outstr .= $text;


### PR DESCRIPTION
While looking through the code I noticed that two URLs no longer pointed to the correct information: one a link to errata in Perl Best Practices (from within `.perltidyrc`), and one link to a patch attached to a ticket in RT.  Fortunately, RT advised what the correct transation number was so that the URL was then easy to correct.